### PR TITLE
Remove AXI slice dependency.

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -1,9 +1,6 @@
 package:
   name: axi2per
 
-dependencies:
-  axi_slice: { git: "https://github.com/pulp-platform/axi_slice.git", version: 1.1.3 }
-
 sources:
   # Level 0
   - axi2per_req_channel.sv


### PR DESCRIPTION
AXI slice is deprecated and was no longer used.